### PR TITLE
feat build: remove warning

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -150,7 +150,7 @@ bool uartSetPins(uint8_t uart_num, int8_t rxPin, int8_t txPin, int8_t ctsPin, in
 {
     if(uart_num >= SOC_UART_NUM) {
         log_e("Serial number is invalid, please use numers from 0 to %u", SOC_UART_NUM - 1);
-        return;
+        return false;
     }
 
     // IDF uart_set_pin() will issue necessary Error Message and take care of all GPIO Number validation.


### PR DESCRIPTION
When building a project, a warning about the absence of a value in the return operator appears

* Is there right place to request changes ?